### PR TITLE
コメント機能を実装する

### DIFF
--- a/src/components/common/Comments.astro
+++ b/src/components/common/Comments.astro
@@ -1,0 +1,22 @@
+---
+
+---
+
+<section>
+  <script src="https://giscus.app/client.js"
+    data-repo="salieri256/portfolio"
+    data-repo-id="R_kgDOPCHQOg"
+    data-category="Announcements"
+    data-category-id="DIC_kwDOPCHQOs4Ct9we"
+    data-mapping="pathname"
+    data-strict="0"
+    data-reactions-enabled="1"
+    data-emit-metadata="0"
+    data-input-position="bottom"
+    data-theme="preferred_color_scheme"
+    data-lang="ja"
+    data-loading="lazy"
+    crossorigin="anonymous"
+    async>
+  </script>
+</section>

--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -2,6 +2,7 @@
 import { type CollectionEntry, getCollection } from 'astro:content';
 import BlogPost from '@/layouts/BlogPost.astro';
 import { render } from 'astro:content';
+import Comments from '@/components/common/Comments.astro';
 
 export async function getStaticPaths() {
 	const posts = await getCollection('blog');
@@ -18,4 +19,5 @@ const { Content } = await render(post);
 
 <BlogPost {...post.data}>
 	<Content />
+	<Comments />
 </BlogPost>


### PR DESCRIPTION
## 実施タスク

close #14 

## やったこと

- ブログのポストごとにリアクションとコメントをつけられるようにした
  - giscusと，このリポジトリのDiscussions機能を連携した
    - リポジトリ
      - `salieri256/portfolio`
    - ページとDiscussions連携設定
      - Discussionのタイトルにページの`pathname`を利用する
    - Discussionで使用するカテゴリ
      - `Announcements`
      - このカテゴリのみを検索する
    - 機能
      - 記事へのリアクションを有効にする
      - コメントのロードを遅延させる
    - テーマ
      - カラースキームに従う
  - GitHubアカウントでログインが必要

## レビューすること

- ブログのポスト詳細ページの下部から以下の動作が行なえること
  - リアクション
  - コメント
- リアクションとコメントが，このリポジトリのDiscussionsから見れること

## 備考

- [giscus](https://giscus.app/ja)
